### PR TITLE
Micro improvements and comment fixes

### DIFF
--- a/docs/src/bump_on_tail.md
+++ b/docs/src/bump_on_tail.md
@@ -43,5 +43,5 @@ sol = solve!(prob, stepper, dt, nsteps )
 ```
 
 ```@example 3
-plot(t, sol, label=L"\frac{1}{2} \log(∫e²dx)")
+plot(t, sol, label=L"\frac{1}{2} \log(\int e^2dx)")
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -259,7 +259,7 @@ equation
 ```math
 \partial_t f + E^\star\partial_v f = 0, 
 ```
-using the semi-Lagrangian method $f^{\star\star}_{i, j} approx f^n(x_i, v_j-E^\star_i \Delta t)$. 
+using the semi-Lagrangian method $f^{\star\star}_{i, j} \approx f^n(x_i, v_j-E^\star_i \Delta t)$. 
   
 + Compute $f^\star_{i,j}$ solving
 ```math

--- a/docs/src/tsi.md
+++ b/docs/src/tsi.md
@@ -29,7 +29,7 @@ for (i,x) in enumerate(xgrid.points), (j,v) in enumerate(vgrid.points)
                    exp(-.5*(v - v0)^2) + exp(-.5*(v + v0)^2))
 end
 
-contour(vgrid.points, xgrid.points, df.values)
+contourf(vgrid.points, xgrid.points, df.values)
 ```
 
 ```@example tsi

--- a/src/VlasovSolvers.jl
+++ b/src/VlasovSolvers.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module VlasovSolvers
 
   using FFTW, LinearAlgebra, Statistics

--- a/src/fourier.jl
+++ b/src/fourier.jl
@@ -10,14 +10,12 @@ struct Fourier <: AbstractMethod
         nx  = meshx.len
         dx  = meshx.step
         Lx  = meshx.stop - meshx.start
-        kx  = zeros(Float64, nx)
-        kx .= 2π/Lx .* [0:nx÷2-1;-nx÷2:-1]
+        kx  = 2π/Lx .* [0:nx÷2-1;-nx÷2:-1]
 
         nv  = meshv.len
         dv  = meshv.step
         Lv  = meshv.stop - meshv.start
-        kv  = zeros(Float64, nv)
-        kv .= 2π/Lv .* [0:nv÷2-1;-nv÷2:-1]
+        kv  = 2π/Lv .* [0:nv÷2-1;-nv÷2:-1]
 
         new( kx, kv)
 
@@ -31,7 +29,7 @@ function advection_v!(fᵗ  :: Array{ComplexF64,2},
 		      e   :: Vector{ComplexF64}, 
 		      dt  :: Float64 )
     fft!(fᵗ, 1)
-    fᵗ .= fᵗ .* exp.(-1im * dt * adv.kv * transpose(e))
+    @. fᵗ *= exp(-1im * dt * adv.kv * $transpose(e))
     ifft!(fᵗ, 1)
 
 end


### PR DESCRIPTION
Hello,

Here are some proposed changes to the code in this PR:
1. Fix more typos in comments;
2. Pass the order of BSpline all the way down to the solver (previously it always runs with 5th order);
3. Remove some unnecessary preallocations;
4. Merge some expressions into single lines; 
5. contour --> contourf for visualizing the initial distribution function in the 2-stream instability.

I ran the tests (Btw, the tests do not check results; they are currently only testing if the code can run without error) and the example problems in the documentation to make sure the results are identical.

Hope this helps a little bit! This is a very nice tutorial for me to get more familiar with 1D-1V Vlasov solver under periodic BC.